### PR TITLE
Publish only if sensor.state changed (fixes #12)

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ function pollSensors(_bridge) {
         return console.error('Error polling sensors on Hue bridge %s: %s', bridge.host, sensorA.error.description);
       }
 
-      if (undefined !== sensorB && !equal(sensorA, sensorB)) {
+      if (hasOldState(sensorB) && stateChanged(sensorA, sensorB)) {
         var nameSlug = slugify(sensorA.name);
 
         Object.keys(sensorA.state).forEach(function(key) {
@@ -104,6 +104,17 @@ function pollSensors(_bridge) {
 
     bridge.polling = bridge.skipped = false;
   });
+}
+
+function hasOldState(sensor) {
+  return undefined !== sensor;
+}
+
+function stateChanged(sensorA, sensorB) {
+  var newState = (sensorA && sensorA.state) ? sensorA.state : undefined;
+  var oldState = (sensorB && sensorB.state) ? sensorB.state : undefined;
+
+  return !equal(newState, oldState);
 }
 
 // Exit handling to disconnect client


### PR DESCRIPTION
Currently the switch/sensor `state` is published if any property of the sensor has changed (eg. `sensor.config.reachable` or `sensor.config.battery`).

With these changes publish should only occur only if the `sensor.state` property has changed.

This fixes #12.
